### PR TITLE
get subtitles can load fonts from fonts_dir

### DIFF
--- a/Engine/Core/ONScripter.hpp
+++ b/Engine/Core/ONScripter.hpp
@@ -1178,7 +1178,7 @@ public: // DialogueController wants access to this
 	int getCharacterPostDisplayDelay(char16_t codepoint, int speed);
 	int unpackInlineCall(const char *cmd, int &val);
 	const char *getFontPath(int i, bool fallback = true);
-    const char *getFontDir();
+	const char *getFontDir();
 
 private:
 	void enterTextDisplayMode();

--- a/Engine/Core/ONScripter.hpp
+++ b/Engine/Core/ONScripter.hpp
@@ -1178,6 +1178,7 @@ public: // DialogueController wants access to this
 	int getCharacterPostDisplayDelay(char16_t codepoint, int speed);
 	int unpackInlineCall(const char *cmd, int &val);
 	const char *getFontPath(int i, bool fallback = true);
+    const char *getFontDir();
 
 private:
 	void enterTextDisplayMode();

--- a/Engine/Core/Text.cpp
+++ b/Engine/Core/Text.cpp
@@ -12,7 +12,9 @@
 #include "Engine/Components/Fonts.hpp"
 #include "Engine/Graphics/Common.hpp"
 #include "Support/Unicode.hpp"
-
+#ifdef WIN32
+#include "windows.system.h"
+#endif
 // Should probably use regex
 bool ONScripter::isAlphanumeric(char16_t codepoint) {
 	if (codepoint >= u'a' && codepoint <= u'z')
@@ -1006,6 +1008,19 @@ const char *ONScripter::getFontPath(int i, bool /*fallback*/) {
 	if (!path)
 		path = sentence_font.getFontPath(0);
 	return path;
+}
+
+const char *ONScripter::getFontDir() {
+#ifdef WIN32
+	//libass doesn't support unicode path, convert it to ANSI on Windows.
+	auto wpath = decodeUTF8StringWide(fonts.fontdir) + L'\0';
+	int len = WideCharToMultiByte(CP_ACP, 0, wpath.c_str(), -1, NULL, 0, NULL, NULL);
+	char *ansipath = static_cast<char *>(malloc(len));
+	WideCharToMultiByte(CP_ACP, 0, wpath.c_str(), -1, ansipath, len, NULL, NULL);
+	return ansipath;
+#else
+	return fonts.fontdir;
+#endif
 }
 
 void ONScripter::addTextWindowClip(DirtyRect &rect) {

--- a/Engine/Media/SubtitleDriver.cpp
+++ b/Engine/Media/SubtitleDriver.cpp
@@ -225,7 +225,7 @@ bool SubtitleDriver::init(int width, int height, const char *ass_sub_file, BaseR
 			ass_library = nullptr;
 			sendToLog(LogLevel::Error, "ass_renderer_init failed!\n");
 		} else {
-            ass_set_fonts_dir(ass_library, ons.getFontDir());
+			ass_set_fonts_dir(ass_library, ons.getFontDir());
 			ass_set_frame_size(ass_renderer, width, height);
 			ass_set_fonts(ass_renderer, ons.getFontPath(currentFontID, true), "Sans", ASS_FONTPROVIDER_NONE, nullptr, 0);
 			bool subs_ok{false};

--- a/Engine/Media/SubtitleDriver.cpp
+++ b/Engine/Media/SubtitleDriver.cpp
@@ -225,7 +225,7 @@ bool SubtitleDriver::init(int width, int height, const char *ass_sub_file, BaseR
 			ass_library = nullptr;
 			sendToLog(LogLevel::Error, "ass_renderer_init failed!\n");
 		} else {
-			//ass_set_fonts_dir(ass_library,nullptr);
+            ass_set_fonts_dir(ass_library, ons.getFontDir());
 			ass_set_frame_size(ass_renderer, width, height);
 			ass_set_fonts(ass_renderer, ons.getFontPath(currentFontID, true), "Sans", ASS_FONTPROVIDER_NONE, nullptr, 0);
 			bool subs_ok{false};


### PR DESCRIPTION
because libass doesn't support unicode paths, just convert them to ANSI on Windows that will work as expected.

for non-Windows , I think it will work but need some testing.