### PR TITLE
Optimise software subtitle rendering by reducing allocations & avoiding FPU

### DIFF
--- a/Engine/Media/SubtitleDriver.hpp
+++ b/Engine/Media/SubtitleDriver.hpp
@@ -53,8 +53,8 @@ public:
 	bool blendOn(SDL_Surface *surface, uint64_t timestamp);
 	bool blendOn(uint8_t *planes[4], size_t planesCnt, AVPixelFormat format, int linesize[AV_NUM_DATA_POINTERS], int height, uint64_t timestamp);
 	bool blendInNeed(SDL_Surface *surface, uint64_t timestamp);
-	bool blendBufInNeed(float *buffer, size_t width, size_t height, int format, uint64_t timestamp, ASS_Image *img = nullptr);
-	bool extractFrame(std::vector<SubtitleImage> &images, uint64_t timestamp); /* Extracts all Ass_Image`s for this timestamp */
+	void blendBufInNeed(uint8_t *buffer, size_t width, int format, ASS_Image *img);
+	int extractFrame(std::vector<SubtitleImage> &images, uint64_t timestamp, ASS_Image **imgptr); /* Extracts all Ass_Image`s for this timestamp */
 private:
 	ASS_Library *ass_library{nullptr};   // libass library (handle)
 	ASS_Renderer *ass_renderer{nullptr}; // libass renderer

--- a/ONScripter.xcodeproj/project.pbxproj
+++ b/ONScripter.xcodeproj/project.pbxproj
@@ -1879,7 +1879,7 @@
 		1C0A5F5717478DCF004A9BCC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1150;
 				TargetAttributes = {
 					1C9F26D51ADB0E7900138E84 = {
 						CreatedOnToolsVersion = 6.3;


### PR DESCRIPTION
Can be tested by

```
setfps 60
anim s0_2,"no64",0
flush 1
bgmplay2 58,100,1
lsp s0_5,"*8"
flush 1
click
*again
click
goto *again

goto *boot_logo
```

CC @copyliu 