### PR TITLE
Add arm64 support

### DIFF
--- a/Dependencies/build.sh
+++ b/Dependencies/build.sh
@@ -652,6 +652,8 @@ getTargetCPU() {
         linux-like)
             if [ "$(uname -m)" == "x86_64" ]; then
                 echo "x86_64"
+            elif [ "$(uname -m)" == "aarch64" ]; then
+                echo "aarch64"
             else
                 echo "i686"
             fi

--- a/Dependencies/pkgs/smpeg2.pkgbuild
+++ b/Dependencies/pkgs/smpeg2.pkgbuild
@@ -49,6 +49,10 @@ prebuild() {
     apply_patch "${sources[4]}"
     apply_patch "${sources[5]}"
 
+    if [ "$(getTarget)" == "linux-like" ] && [ "$(getTargetCPU)" == "aarch64" ]; then
+        apply_patch "${sources[6]}"
+    fi
+    
     if [ "$(getTarget)" == "droid" ]; then
         apply_patch "${sources[6]}"
         apply_patch "${sources[7]}"

--- a/Resources/Docs/Compilation.md
+++ b/Resources/Docs/Compilation.md
@@ -307,6 +307,14 @@ chmod +x configure Scripts/* Dependencies/build.sh
 
 _Unlike macOS (manual architecture specification) and Windows (untested 64-bit binary), the executable architecture on Linux depends on the default compiler architecture. On 32-bit systems 32-bit binaries are normally produced and on 64-bit systems — 64-bit binaries._
 
+#### arm64 Debian
+
+Same as above but you will need to add `--prefer-clang` to the configure script when you proceed using the generic method of compilation at the beginning of these instructions. Not before installing the required clang packages however:
+
+```
+apt-get install clang libclang-dev
+```
+
 #### Linux OpenSUSE
 
 1. You will need a number of packages (similarly to Debian). Install them with YaST or whatever you like:


### PR DESCRIPTION
Since I am not sure why a newer `config.guess` and `config.sub` are used only when building smpeg2 for Android, I decided to do the same if the script detects that the project is being built for arm64 linux, so that's `linux-like` for `getTarget` and `aarch64` for `getTargetCPU`. `aarch64` did not exist in `getTargetCPU` for `linux-like`, so I added it.

And finally I mentioned how to build it for arm64 Debian in the documentation.

Bellow is a screenshot of the game running on my Raspberry Pi 4 (64-bit Raspberry Pi OS, which is basically Debian) after built using these exact commit(s) applied.

![2021-05-18-171040_1920x1080_scrot](https://user-images.githubusercontent.com/5400432/118657048-29735d00-b7fc-11eb-9fa4-3b6c7bd6e3fd.png)
