### PR TITLE
add a new Chinese punctuation mark support:  Mark of indicating death

### DIFF
--- a/Engine/Components/Dialogue.cpp
+++ b/Engine/Components/Dialogue.cpp
@@ -1337,7 +1337,7 @@ void DialogueController::renderAddedChars(TextRenderingState &state, DialoguePie
 	auto fiIterator = p.fontInfos.begin();
 	bool wordBorder = false;
 	SDL_Color wordBorderColor;
-	GPU_Rect borderRect;
+	GPU_Rect borderRect = GPU_MakeRect(0, INT_MAX, 0, 0);
 	int wordBorderSize = 0;
 	// We only need a copy of the fontInfo in the renderShadow case.
 	cmp::optional<Fontinfo> opt;

--- a/Engine/Components/Dialogue.cpp
+++ b/Engine/Components/Dialogue.cpp
@@ -1335,7 +1335,10 @@ void DialogueController::addCharToRenderBuffer(DialoguePiece &piece, char16_t co
 void DialogueController::renderAddedChars(TextRenderingState &state, DialoguePiece &p, bool renderBorder, bool renderShadow) {
 	float x         = 0;
 	auto fiIterator = p.fontInfos.begin();
-
+	bool wordBorder = false;
+	SDL_Color wordBorderColor;
+	GPU_Rect borderRect;
+	int wordBorderSize = 0;
 	// We only need a copy of the fontInfo in the renderShadow case.
 	cmp::optional<Fontinfo> opt;
 
@@ -1366,6 +1369,29 @@ void DialogueController::renderAddedChars(TextRenderingState &state, DialoguePie
 
 		// For border/shadow, only do the draw if the fontInfo style says we are supposed to
 		auto &style = fontInfo.style();
+		if (style.word_border) {
+			if (!wordBorder) {
+				// bordered word init
+				wordBorder      = true;
+				wordBorder      = style.word_border;
+				borderRect.x    = x + state.offset.x + p.position.x;
+				borderRect.y    = SDL_min(borderRect.y, p.baseline + state.offset.y + p.position.y - glyph->maxy);
+				wordBorderColor = fontInfo.getGlyphParams().glyph_color;
+				wordBorderSize  = style.word_border_size;
+			}
+			borderRect.h = SDL_max(borderRect.h, glyph->maxy - glyph->miny);
+		}
+		if (wordBorder && !style.word_border) {
+			if (!renderBorder && !renderShadow) {
+				// render word border
+				borderRect.w = x + state.offset.x + p.position.x - borderRect.x;
+				renderBorderedWord(state, wordBorderColor, borderRect, wordBorderSize);
+			}
+			// reset border word status
+			borderRect = GPU_MakeRect(0, INT_MAX, 0, 0);
+			wordBorder = false;
+		}
+
 		if (renderReady && !(renderBorder && !style.is_border) && !(renderShadow && !style.is_shadow)) {
 			int alpha{255};
 
@@ -1385,6 +1411,39 @@ void DialogueController::renderAddedChars(TextRenderingState &state, DialoguePie
 		x += glyph->advance;
 		//TODO: These 3 lines are code duplication, see addCharToRenderBuffer; extract them into a float Fontinfo::getTotalAdvance(wchar_t codepoint) method.
 		// (maybe there is a better name...)
+	}
+	if (wordBorder) {
+		if (!renderBorder && !renderShadow) {
+			// if pieces end and border inited, render it
+			borderRect.w = x + state.offset.x + p.position.x - borderRect.x;
+			renderBorderedWord(state, wordBorderColor, borderRect, wordBorderSize);
+		}
+	}
+}
+
+void DialogueController::renderBorderedWord(TextRenderingState &state, SDL_Color &wordBorderColor, GPU_Rect &borderRect, int wordBorderSize) {
+	if (state.dst.target) {
+		for (int i = 0; i < wordBorderSize; ++i) {
+			GPU_Rectangle2(state.dst.target, borderRect, wordBorderColor);
+			borderRect.x -= 1;
+			borderRect.w += 2;
+			borderRect.y -= 1;
+			borderRect.h += 2;
+		}
+	} else {
+		for (int i = 0; i < wordBorderSize; ++i) {
+			auto images = state.dst.bigImage->getImagesForArea(borderRect);
+			for (auto &image : images) {
+				GPU_Target *target = image.first->target;
+				GPU_Rectangle(target, borderRect.x - image.second.x, borderRect.y - image.second.y,
+				              borderRect.x - image.second.x + borderRect.w, borderRect.y - image.second.y + borderRect.h,
+				              wordBorderColor);
+			}
+			borderRect.x -= 1;
+			borderRect.w += 2;
+			borderRect.y -= 1;
+			borderRect.h += 2;
+		}
 	}
 }
 

--- a/Engine/Components/Dialogue.hpp
+++ b/Engine/Components/Dialogue.hpp
@@ -391,6 +391,7 @@ private:
 	bool addFittingChars(DialoguePiece &piece, std::u16string &rhs, const std::u16string &original, std::deque<DialoguePiece> *rubyPieces = nullptr, bool measure = false);
 	void addCharToRenderBuffer(DialoguePiece &piece, char16_t codepoint, Fontinfo &fontInfo, bool measure = false);
 	void renderAddedChars(TextRenderingState &state, DialoguePiece &p, bool renderBorder = false, bool renderShadow = false);
+	void renderBorderedWord(TextRenderingState &state, SDL_Color &wordBorderColor, GPU_Rect &borderRect, int wordBorderSize) ;
 
 	// temps with preallocated buffers
 	std::u16string layoutPieceTmpFreshText;

--- a/Engine/Core/ONScripter.hpp
+++ b/Engine/Core/ONScripter.hpp
@@ -55,6 +55,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <limits>
 
 const int MAX_SPRITE_NUM = 1000;
 const int MAX_TEXT_TREES = 50;

--- a/Engine/Core/Text.cpp
+++ b/Engine/Core/Text.cpp
@@ -457,6 +457,13 @@ bool ONScripter::executeInlineTextCommand(std::string &command, std::string &par
 		return false;
 	};
 
+	auto processWordBorder = [](std::string & /* command */, std::string &param /* param */, Fontinfo &info) {
+		info.changeStyle().no_break = true;
+		info.changeStyle().word_border = true;
+		info.changeStyle().word_border_size = std::stoi(param);
+		return false;
+	};
+
 	if (processFuncs.empty()) {
 		processFuncs["italic"] = processFuncs["i"] = processItalic;
 		processFuncs["bold"] = processFuncs["b"] = processBold;
@@ -494,6 +501,8 @@ bool ONScripter::executeInlineTextCommand(std::string &command, std::string &par
 		processFuncs["color"] = processFuncs["colour"] = processFuncs["c"] = processColour;
 		processFuncs["shadowcolor"] = processFuncs["shadowcolour"] = processFuncs["v"] = processShadowColour;
 		processFuncs["bordercolor"] = processFuncs["bordercolour"] = processFuncs["r"] = processBorderColour;
+
+		processFuncs["wborder"] = processWordBorder;
 	}
 
 	auto cmd = processFuncs.find(command);

--- a/Engine/Entities/Font.hpp
+++ b/Engine/Entities/Font.hpp
@@ -127,6 +127,9 @@ public:
 
 		bool no_break{false};
 
+		bool word_border{false};
+		int word_border_size{0};
+
 		int font_size{0};
 
 		std::string ruby_text;
@@ -168,6 +171,8 @@ public:
                 shadow_distance[1] = props.shadow_distance[1];
             shadow_color = props.shadow_color;
             no_break     = props.no_break;
+			word_border  = props.word_border;
+			word_border_size = props.word_border_size;
             if (props.font_size != -1)
                 font_size = props.font_size;
             character_spacing = props.character_spacing;


### PR DESCRIPTION
We introduce a new feature with a heavy heart.

Mark of indicating death.

In Chinese, this punctuation mark is used to mark that the person has deceased, and appears to be a box over the name.

example: `{wborder:5:疾风云扬}` , 5 is border width.

```Chinese translation chief proofreader --疾风云扬, RIP.```